### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pages: write
 name: main.yml
 on:
   push:
@@ -27,4 +30,3 @@ jobs:
           publish_branch: gh-pages
           publish_dir: ./doc
           force_orphan: true
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ permissions:
   contents: write
 
 on:
-  pull_request:
   push:
     branches: [ main ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
-permissions:
-  contents: read
-  pages: write
 name: main.yml
+
+permissions:
+  pages: write
+
 on:
+  pull_request:
   push:
     branches: [ main ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: main.yml
 
 permissions:
-  pages: write
+  contents: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ngudbhav/rails-api-boilerplate/security/code-scanning/1](https://github.com/ngudbhav/rails-api-boilerplate/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow (applying it to all jobs) and explicitly define the minimal permissions required for the actions in this workflow. 

The `contents: read` permission will be set to allow read access to the repository's files, which is necessary for the `actions/checkout` step. Additionally, `pages: write` will be added to allow deployment to GitHub Pages in the `peaceiris/actions-gh-pages` step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
