### PR TITLE
fix: Grouped Dependencies Update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,8 +86,8 @@ GEM
       activesupport (>= 6.0.0)
     ast (2.4.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1253.0)
-    aws-sdk-core (3.249.0)
+    aws-partitions (1.1260.0)
+    aws-sdk-core (3.252.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -95,10 +95,10 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.128.0)
+    aws-sdk-kms (1.129.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.224.0)
+    aws-sdk-s3 (1.225.1)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -107,9 +107,9 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bigdecimal (4.1.2)
-    bootsnap (1.24.5)
+    bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     cgi (0.5.1)
@@ -140,7 +140,7 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    image_processing (2.0.1)
+    image_processing (2.0.2)
     io-console (0.8.2)
     irb (1.18.0)
       pp (>= 0.6.0)
@@ -148,7 +148,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.19.5)
+    json (2.19.9)
     jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.5)
@@ -168,8 +168,8 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.0)
-    net-imap (0.6.4)
+    msgpack (1.8.3)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -187,12 +187,12 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    phonelib (0.10.20)
+    phonelib (0.10.22)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     puma (8.0.2)
@@ -251,7 +251,7 @@ GEM
       tsort
     redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.29.0)
+    redis-client (0.30.0)
       connection_pool
     regexp_parser (2.12.0)
     reline (0.6.3)
@@ -278,7 +278,7 @@ GEM
       rspec-mocks (~> 3.0)
       sidekiq (>= 5, < 9)
     rspec-support (3.13.7)
-    rubocop (1.86.2)
+    rubocop (1.87.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -296,7 +296,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.2)
+    rubocop-rails (2.35.4)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -311,10 +311,10 @@ GEM
       ffi (~> 1.12)
       logger
     securerandom (0.4.1)
-    sentry-rails (6.5.0)
+    sentry-rails (6.6.2)
       railties (>= 5.2.0)
-      sentry-ruby (~> 6.5.0)
-    sentry-ruby (6.5.0)
+      sentry-ruby (~> 6.6.2)
+    sentry-ruby (6.6.2)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
@@ -350,12 +350,12 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.1)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     yard (0.9.44)
-    zeitwerk (2.8.1)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   arm64-darwin-24


### PR DESCRIPTION
# Changelog

All notable dependency updates to this project are documented here.

---

## [Unreleased] — 2026-06-15

---

### Major Version Bumps

---

#### `discard` — 1.4.0 → 2.0.0

**2.0.0**
- Requires ActiveRecord >= 7.0; drops support for Rails 6.x and earlier
- Wraps `#discard` and `#undiscard` in a transaction so callback exceptions roll back the DB write

**1.4.0** _(intermediate)_
- Enabled compatibility with Rails 8.0 and 8.1
- More descriptive error messaging

---

#### `puma` — 7.1.0 → 8.0.2

**8.0.2**
- Security fixes for PROXY protocol v1 regex injection and keep-alive spoofing

**8.0.1**
- Fixed bundler environment variable stripping that caused worker crashes
- Performance improvements using blocks for debug logging

**8.0.0** _(breaking)_
- New `env["puma.mark_as_io_bound"]` API and `max_io_threads` for mixed CPU/IO workloads
- Added `single` and `cluster` DSL hooks for mode-specific setup
- Runtime thread pool adjustment via `update_thread_pool_min_max`
- Response header caching — reduces allocations by ~50% per response
- Default production bind address changed to IPv6 when available, falling back to IPv4
- Multiple hook name changes (e.g. `on_worker_boot` → `before_worker_boot`)
- **Breaking:** Minimum Ruby version raised to 3.0

**7.2.0** _(intermediate)_
- Added `workers: :auto` configuration option
- 17% faster HTTP parsing via pre-interned environment keys
- Enhanced GC compactibility for `Puma::HttpParser`

---

#### `image_processing` — 1.14.0 → 2.0.2

**2.0.2**
- Raises `LoadError` instead of `ImageProcessing::Error` when soft dependencies (mini_magick, ruby-vips) are missing

**2.0.1**
- Security fix: prevents remote shell execution vulnerability when passing loader/saver options from user input in MiniMagick

**2.0.0** _(breaking)_
- `mini_magick` and `ruby-vips` are now soft dependencies — must be added to Gemfile manually
- Security fix: blocks remote shell execution in `#apply` when arguments come from user input
- Unfuzzed VIPS loaders are blocked by default
- Sharpening after resize is disabled by default in VIPS
- Removed deprecated `:compose` and `:geometry` keyword arguments for `#composite`
- **Breaking:** Requires Ruby 3.0 or newer

**1.14.0** _(intermediate)_
- Support for MiniMagick 5.x
- Fixed `#resize_to_cover` for images with EXIF orientation data

---

#### `brakeman` — 7.1.1 → 8.0.5

**8.0.5**
- Added `quote_schema_name` to safe quote method list
- Fixed SQL injection false positives for `compact_blank`/`compact` on permitted parameters
- Fixed inline render false positive for local variables named `text`
- Resolved HAML crash on `.raw` calls
- Fixed `TemplateAliasProcessor#template_name` arity issue

**8.0.4**
- Added loading of `date` library for the `--ensure-latest` option

**8.0.3**
- Fixed `polymorphic_name` SQL injection false positive
- Introduced release age option for `--ensure-latest`
- Enhanced handling of application names with module prefixes

**8.0.2**
- Corrected Reline console control to use stderr

**8.0.1**
- Ensured cursor resets even when exit code returns zero

**8.0.0** _(breaking)_
- Removed `--skip-libs` and `--index-libs` options
- Overhauled scan progress output and logging systems
- Replaced Erubis parser with Erubi
- Eliminated weak dynamic render path warnings
- Accelerated file globbing for templates

**7.1.2** _(intermediate)_
- Updated `ruby_parser` to remove version restrictions
- **Breaking:** Raised minimum required Ruby version to 3.2.0
- Migrated to Minitest 6.0
- Decreased SQL injection false positives from `count` calls

---

### Minor Version Bumps

---

#### `rails` — 8.1.1 → 8.1.3

**8.1.3**
- _ActiveSupport:_ Fixed `JSONGemCoderEncoder` for custom object hash key serialization; fixed inflections with overlapping acronyms; silenced Dalli 4.0+ warning
- _ActiveModel:_ Fixed Ruby 4.0 delegator warning on `inspect`; fixed `NoMethodError` when deserializing `Type::Integer` objects marshalled under Rails 8.0
- _ActiveRecord:_ Fixed `insert_all`/`upsert_all` log message for anonymous classes; respect `ignore_tables` for SQLite virtual table dumps; restored instrumenter after `execute_or_skip`

**8.1.2**
- _ActiveSupport:_ Fixed `delegate`/`delegate_missing_to` in `BasicObject` subclasses; fixed Inflectors with locale fallback to `:en`; fixed `TimeWithZone#as_json` to consistently return UTF-8
- _ActiveRecord:_ Fixed counting cached queries in `RuntimeRegistry`; fixed merging relations with null relations; fixed PostgreSQL `schema_search_path` not reapplied after `reset!`/`reconnect!`; restored ability for enum values to be floats (regression from 8.1.0)

---

#### `sidekiq` — 8.0.10 → 8.1.6

**8.1.6**
- Fixed a thread/memory leak occurring when jobs fail
- Added `only=(jobs|processes)` parameter to the Busy page
- Replaced `Rack::Utils` usage with standard library APIs

**8.1.5**
- Fixed sub-second precision when calculating the `retry_for` deadline
- Identifies Sidekiq connections in Redis using `CLIENT SETINFO`
- Fixed edge case where Web UI could display an empty Batch set

**8.1.4**
- Restored TTIN signal support (INFO signal lacks Linux support)
- Displays iteration job state on the Busy page

**8.1.3**
- Fixed edge case that could trigger duplicate, concurrent job execution
- **Security:** Substantially reduced YAML usage; localization files now manually parsed
- `Sidekiq::CLI` only requires YAML when using a `-C .yml` file

**8.1.2**
- Introduced `kiq` — Sidekiq's official terminal UI (`bundle exec kiq`)
- Fixed mutation issue in `SortedSet#each` that caused iteration to skip half the jobs

**8.1.1**
- Deprecated `require 'sidekiq/testing'` patterns — replaced with `Sidekiq.testing!(mode)` API
- Fixed race condition with Stop button in the UI

**8.1.0**
- Made `retry_for` and `retry` mutually exclusive options
- Removed CSRF code in favor of `Sec-Fetch-Site` header validation
- Upgraded to connection_pool 3.0
- Introduced beta idle connection reaping feature

**8.0.10** _(intermediate)_
- Added confirmation dialogs for Delete All buttons in Web UI
- Forward compatibility changes for connection_pool 3.0.0

---

#### `rubocop` — 1.81.7 → 1.87.0

**1.87.0**
- Added `--enable-all-cops` and `--disable-all-cops` command line options
- Optional Rubydex integration via `AllCops/UseProjectIndex` for cross-file detection
- Cached `FilePatterns#match?` results to improve performance with shared configurations
- Fixed false positives in `Lint/ParenthesesAsGroupedExpression`, `Style/YodaCondition`

**1.86.2**
- Implemented true runner parallelism
- Fixed cache usage with parallelization; fixed `--disable-uncorrectable` infinite loops

**1.86.1**
- Fixed `Style/AccessModifierDeclarations` dropping comments during autocorrection
- Fixed `Lint/DuplicateMethods` false positives with anonymous classes
- Made `Style/OneClassPerFile` exclude `spec/**/*` and `test/**/*` by default

**1.86.0**
- Added `AllowedParentClasses` option to `Style/EmptyClassDefinition`
- Display ZJIT usage when running under LSP
- Removed `mcp` gem from runtime dependencies

**1.85.1**
- Fixed `Style/FileOpen` false positives; autoloaded formatters for better performance

**1.85.0**
- Added 11 new Style cops: `FileOpen`, `MapJoin`, `OneClassPerFile`, `PartitionInsteadOfDoubleSelect`, `PredicateWithKind`, `ReduceToHash`, `RedundantMinMaxBy`, `SelectByKind`, `SelectByRange`, `TallyMethod`
- New `Lint/UnreachablePatternBranch` and `Lint/DataDefineOverride` cops
- Added `mise.toml` as source for `TargetRubyVersion`
- Support for built-in MCP server (experimental)

**1.84.2**
- Fixed clobbering errors in `Style/BlockDelimiters` and infinite loop in layout cops

**1.84.0**
- Added 4 new Style cops: `EmptyClassDefinition`, `HashLookupMethod`, `NegativeArrayIndex`, `ReverseFind`
- New push/pop local system for directive handling
- Support `TargetRubyVersion 4.1` (experimental)

**1.82.0**
- Added new `Style/ModuleMemberExistenceCheck` cop
- Support `TargetRubyVersion 4.0` (experimental)
- Made `Lint/DuplicateMethods` aware of Active Support's `delegate` method

---

#### `sentry-ruby` / `sentry-rails` — 6.2.0 → 6.6.2

**6.6.2**
- Fixed duplicate attributes in metrics capture

**6.6.1**
- Guarded `TelemetryEventBuffer` against re-entrant mutex acquisition

**6.6.0**
- Introduced `sentry-yabeda` gem for Sentry Metrics + Yabeda monitoring integration
- Added release detection from Kamal deployment configuration
- Improved memory performance with filename/line caching enhancements

**6.5.0**
- Added collector URL option to OTLP integration
- Updated Heroku release detection to prefer `HEROKU_BUILD_COMMIT`
- Mapped `trilogy` database adapter to `mysql` for Query Insights compatibility
- Fixed baggage header preservation in requests

**6.4.1**
- Enabled request queue time tracking in Rails middleware

**6.4.0**
- Added OTLP ingestion support in `sentry-opentelemetry`
- Implemented queue time capture for Rack applications
- Fixed CGI imports for Ruby 4.x compatibility

**6.3.1**
- Used `ActionDispatch::ExceptionWrapper` for correct HTTP status codes
- Added explicit `logger` gem dependency for Ruby 4.0 compatibility

**6.3.0**
- Implemented Sentry Trace Connected Metrics with count, distribution, gauge operations
- Added support for tracing Sequel database queries
- Unified Logs and Metrics implementations with maximum buffer limits

---

#### `trilogy` — 2.9.0 → 2.12.5

**2.12.5**
- Properly set `FD_CLOEXEC` on sockets to prevent file descriptor leakage during exec

**2.12.4**
- Workaround for compilation issues on older Ruby versions with Xcode 26.4+

**2.12.3**
- Excluded `Trilogy#server_version` from the synchronization mutex

**2.12.2**
- Fixed incorrect usec handling for local time casting

**2.12.0**
- Improved result parsing and type casting performance, especially for datetime fields
- Introduced `Trilogy::Result#in_transaction?` method

**2.11.0**
- Added support for `caching_sha2_password` over TCP without TLS
- Introduced `Trilogy#abandon_results!` as an optimized alternative for result cleanup
- Explicit error raised when a single connection is used concurrently by multiple threads/fibers
- Ensured column names in results use connection encoding

**2.10.0**
- Added `size` alias for `Trilogy::Result#count`
- Declared `bigdecimal` dependency for Ruby 3.4+
- Accelerated `Trilogy#escape` performance by 3–5x
- Implemented a buffer pool

---

#### `strong_migrations` — 2.5.1 → 2.8.0

**2.8.0**
- Added check for `rename_enum_value`

**2.7.0**
- Added check for `add_foreign_key` with MySQL and MariaDB
- Added check for `add_column` with callable default value with MySQL and MariaDB

**2.6.0**
- Added check for `algorithm: :copy` with MySQL and MariaDB
- Added check for `lock: :shared` and `lock: :exclusive` with MySQL and MariaDB
- **Breaking:** Dropped support for Ruby < 3.3 and Active Record < 7.2

**2.5.2** _(intermediate)_
- Fixed false positive for `add_reference` with `foreign_key: {validate: false}`

---

#### `thruster` — 0.1.16 → 0.1.21

**0.1.21**
- Built with Go 1.26.3

**0.1.20**
- Only redirect HTTP→HTTPS for policy-allowed hosts

**0.1.19**
- Built with Go 1.26.1

**0.1.18**
- Returns correct exit code when terminated with a signal
- Built with Go 1.25.6

**0.1.17**
- Mitigates BREACH attacks with random jitter and optional compression guard

---

#### `rspec-sidekiq` — 5.2.0 → 5.3.0

**5.3.0**
- New `have_job` matcher for asserting jobs in Sidekiq named queues (ScheduledSet, RetrySet, DeadSet) with argument, count, and set-specific filters
- Opt-in in-memory named queue stubs via `stub_named_queues: true` for testing without Redis
- New `have_job_option` / `have_job_options` matchers for asserting job options (e.g. retry, queue, backtrace) with fuzzy matching support
- RSpec matchers now usable with the `at` evaluator in `enqueue_sidekiq_job`
- `on` option for queue matching accepts both String and Symbol interchangeably

---

#### `annotaterb` — 4.20.0 → 4.22.0

**4.22.0**
- Fixed non-functional `ignore_multi_database_name` option
- Added support for `ruby-lsp` addon
- Fixed weird annotation behavior when mounting ActionCable
- Implemented `#lease_connection` when available
- Honored `skip_on_db_migrate` config option during migrate tasks

**4.21.0**
- Added database name display for multi-database Rails projects
- Added `to_yard` and `to_rdoc` methods to `Annotation` classes
- Enabled custom config path support
- Introduced `ignore_multi_database_name` option

---

#### `faker` — 3.5.3 → 3.8.0

**3.8.0**
- Introduced lazy loading (`Faker::Config.lazy_loading = true` or `FAKER_LAZY_LOAD=1`) — loads 2x faster by only initializing used generators

**3.7.1**
- Dropped support for Ruby 3.1 (end-of-life)
- Removed constraints on `json_schema` and `public-suffix` dependencies

**3.6.1**
- Fixed security vulnerability related to polynomial regex handling
- Improved performance for Japanese locale postcode generation

**3.6.0**
- Dropped support for Ruby 3.0 (minimum is now Ruby 3.1)
- Removed deprecated generators: `Faker::Twitter` and `Faker::BossaNova`
- Improved load time by 17% through OpenSSL autoloading optimization

---

### Patch Version Bumps

---

#### `rails` — (see Minor section above)

---

#### `aws-sdk-s3` — 1.217.0 → 1.225.1

**1.225.1** — Fixed `download_file` single-request mode to properly write to temporary files for String/Pathname destinations

**1.225.0** — New BDD representation for endpoint ruleset

**1.220.0** — Supports five additional checksum algorithms (MD5, SHA-512, XXHash3/64/128); S3 Inventory support for directory buckets

**1.221.0** — Added validation for outpost access point resource names

**1.219.0** — Updated valid AWS Region values for `LocationConstraint` on general purpose buckets

**1.218.0** — Added Bucket Metrics configuration support to directory buckets

**1.217.1** — Fixed `require_https_for_sse_cpk` option enforcement

**1.217.0–1.224.0** — Code-generated endpoint and API changes

---

#### `bootsnap` — 1.19.0 → 1.24.6

**1.24.6** — Resolved detection issues with Ruby bug #22023 on certain Ruby 3.4 patch versions

**1.24.5** — Skips loading config files when setup occurs manually, preventing CLI tools from unintentionally loading another app's bootsnap config

**1.24.4** — Multiple Ruby 4.0.4 compatibility fixes; decreased cache file header size from 64 to 32 bytes

**1.24.3** — Fixed Ruby file parsing with UTF-8 encoding when `LANG` is absent or set to `"C"`

**1.24.1** — Fixed file encoding when `BOOTSNAP_READONLY` is enabled

**1.24.0** — Introduced a hook API for customizing Ruby compilation

**1.23.0** — Updated minimum Ruby requirement to 2.7; enhanced `BOOTSNAP_IGNORE_DIRECTORIES` support for absolute paths

**1.22.0** — Added `bootsnap/rake` for cache cleaning as part of `rake clobber`

**1.21.1** — Prevented crashes during load path scanning when `opendir` fails without setting `errno`

**1.20.0** — ~2x faster load path scanning via C extension

---

#### `bcrypt` — 3.1.20 → 3.1.22

**3.1.22** — Fixed CVE-2026-33306: integer overflow in the Java extension

**3.1.21** — Implemented constant-time comparisons for enhanced security; declared Ractor-safe

---

#### `phonelib` — 0.10.14 → 0.10.22

**0.10.22 / 0.10.21** — Updated phone number data

**0.10.20** — Removed deprecated `test_files` setting from gemspec

**0.10.18** — Bug fixes (#352, #348); updated phone number data

**0.10.17** — Eager loading code improvements; updated phone number data

**0.10.16** — Updated phone number data

---

#### `yard` — 0.9.37 → 0.9.44

**0.9.44** — Fixed path traversal vulnerability in `yard server`; improved HTML entity support; support for multiple/nested Hash key definitions

**0.9.43** — Fixed attribute registration in `.rbs` files

**0.9.42** — Patched path traversal vulnerability in `yard server`; fixed alternating row display in default HTML templates

**0.9.41** — Added `rdoc-image:...` syntax support; improved responsiveness in `yard server`

**0.9.40** — Support for Ruby `.rbs` files with docstrings; introduced HybridMarkdown renderer; removed jQuery from default templates; extended commonmarker version support to 1.0+

**0.9.39** — Ruby 4.0 compatibility support

**0.9.38** — Added support for complex constant assignments and Data type structs; Ruby 3.5 compatibility improvements

---

#### `rspec-rails` — 8.0.2 → 8.0.4

**8.0.4** — Relaxed version constraint for rspec to allow 4.0.0.beta1

**8.0.3** — Fixed insertion order of controller prefix in view `lookup_context`; fixed `rails stats` to use application root

---

#### `debug` — 1.11.0 → 1.11.1

**1.11.1** — Compatibility and stability improvements for Ruby 4.x

---

### Bundler-Managed Updates (transitive/stdlib)

| Gem | Current Version | Note |
|-----|----------------|-------|
| `nokogiri` | 1.19.3 | Security and compatibility patches |
| `rack` | 3.2.6 | Runtime updates |
| `rack-session` | 2.1.2 | Runtime updates |
| `net-imap` | 0.6.4.1 | stdlib updates |
| `erb` | 6.0.4 | stdlib updates |
| `json` | 2.19.9 | Runtime updates |
| `bcrypt` (bundler group) | 3.1.22 | See patch section above |
